### PR TITLE
Add optimizations for Win32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ doc/api/
 **/*.dll
 **/*.obj
 **/*.exe
+**/*.aot
 
 **/*.pdb
 **/*.ilk

--- a/example/clear.dart
+++ b/example/clear.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+const ansiEraseInDisplayAll = '\x1b[2J';
+const ansiResetCursorPosition = '\x1b[H';
+
+void main() {
+  stdout.write(ansiEraseInDisplayAll + ansiResetCursorPosition);
+}

--- a/example/ffi/constants-win.c
+++ b/example/ffi/constants-win.c
@@ -14,6 +14,7 @@ int main()
     printf("sizeof(HANDLE) is %lu\n", sizeof(HANDLE));
     printf("sizeof(CONSOLE_CURSOR_INFO) is %lu\n", sizeof(CONSOLE_CURSOR_INFO));
 
+    printf("sizeof(TCHAR) is %lu\n", sizeof(TCHAR));
     printf("sizeof(DWORD) is %lu\n", sizeof(DWORD));
     printf("sizeof(WORD) is %lu\n", sizeof(WORD));
     printf("sizeof(SHORT) is %lu\n", sizeof(SHORT));

--- a/example/ffi/ffi-win32.dart
+++ b/example/ffi/ffi-win32.dart
@@ -112,6 +112,15 @@ class SMALL_RECT extends Struct<SMALL_RECT> {
   int Bottom;
 }
 
+// BOOL WINAPI SetConsoleCursorPosition(
+//   _In_ HANDLE hConsoleOutput,
+//   _In_ COORD  dwCursorPosition
+// );
+typedef setConsoleCursorPositionNative = Int8 Function(
+    Int32 hConsoleOutput, Int16 dwCursorPositionX, Int16 dwCursorPositionY);
+typedef setConsoleCursorPositionDart = int Function(
+    int hConsoleOutput, int dwCursorPositionX, int dwCursorPositionY);
+
 main() {
   final DynamicLibrary kernel = DynamicLibrary.open('Kernel32.dll');
 
@@ -120,6 +129,9 @@ main() {
   final GetConsoleScreenBufferInfo = kernel.lookupFunction<
       getConsoleScreenBufferInfoNative,
       getConsoleScreenBufferInfoDart>("GetConsoleScreenBufferInfo");
+  final SetConsoleCursorPosition = kernel.lookupFunction<
+      setConsoleCursorPositionNative,
+      setConsoleCursorPositionDart>("SetConsoleCursorPosition");
 
   final outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
   print(outputHandle);
@@ -128,6 +140,9 @@ main() {
       Pointer<CONSOLE_SCREEN_BUFFER_INFO>.allocate();
   CONSOLE_SCREEN_BUFFER_INFO bufferInfo = pBufferInfo.load();
   GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
-  print(bufferInfo.dwMaximumWindowSizeX);
-  print(bufferInfo.dwMaximumWindowSizeY);
+  print(bufferInfo.srWindowTop);
+  print(bufferInfo.dwCursorPositionY);
+  SetConsoleCursorPosition(outputHandle, 5, 20);
+  print(bufferInfo.srWindowTop);
+  print(bufferInfo.dwCursorPositionY);
 }

--- a/example/ffi/ffi-win32.dart
+++ b/example/ffi/ffi-win32.dart
@@ -80,18 +80,6 @@ class CONSOLE_SCREEN_BUFFER_INFO extends Struct<CONSOLE_SCREEN_BUFFER_INFO> {
             ..dwMaximumWindowSizeY = dwMaximumWindowSize.Y;
 }
 
-// typedef struct _COORD {
-//   SHORT X;
-//   SHORT Y;
-// } COORD, *PCOORD;
-class COORD extends Struct<COORD> {
-  @Int16()
-  int X;
-
-  @Int16()
-  int Y;
-}
-
 // typedef struct _SMALL_RECT {
 //   SHORT Left;
 //   SHORT Top;
@@ -112,14 +100,30 @@ class SMALL_RECT extends Struct<SMALL_RECT> {
   int Bottom;
 }
 
+// typedef struct _COORD {
+//   SHORT X;
+//   SHORT Y;
+// } COORD, *PCOORD;
+class COORD extends Struct<COORD> {
+  @Int16()
+  int X;
+
+  @Int16()
+  int Y;
+}
+
 // BOOL WINAPI SetConsoleCursorPosition(
 //   _In_ HANDLE hConsoleOutput,
 //   _In_ COORD  dwCursorPosition
 // );
 typedef setConsoleCursorPositionNative = Int8 Function(
-    Int32 hConsoleOutput, Int16 dwCursorPositionX, Int16 dwCursorPositionY);
+    Int32 hConsoleOutput, COORD dwCursorPosition);
 typedef setConsoleCursorPositionDart = int Function(
-    int hConsoleOutput, int dwCursorPositionX, int dwCursorPositionY);
+    int hConsoleOutput, COORD dwCursorPosition);
+// typedef setConsoleCursorPositionNative = Int8 Function(
+//     Int32 hConsoleOutput, Int16 dwCursorPositionX, Int16 dwCursorPositionY);
+// typedef setConsoleCursorPositionDart = int Function(
+//     int hConsoleOutput, int dwCursorPositionX, int dwCursorPositionY);
 
 main() {
   final DynamicLibrary kernel = DynamicLibrary.open('Kernel32.dll');
@@ -142,7 +146,7 @@ main() {
   GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
   print(bufferInfo.srWindowTop);
   print(bufferInfo.dwCursorPositionY);
-  SetConsoleCursorPosition(outputHandle, 5, 20);
+  // SetConsoleCursorPosition(outputHandle, 5, 20);
   print(bufferInfo.srWindowTop);
   print(bufferInfo.dwCursorPositionY);
 }

--- a/example/ffi/ffi-win32.dart
+++ b/example/ffi/ffi-win32.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+import 'dart:io';
 
 const STD_INPUT_HANDLE = -10;
 const STD_OUTPUT_HANDLE = -11;
@@ -117,13 +118,9 @@ class COORD extends Struct<COORD> {
 //   _In_ COORD  dwCursorPosition
 // );
 typedef setConsoleCursorPositionNative = Int8 Function(
-    Int32 hConsoleOutput, COORD dwCursorPosition);
+    Int32 hConsoleOutput, Int32 dwCursorPosition);
 typedef setConsoleCursorPositionDart = int Function(
-    int hConsoleOutput, COORD dwCursorPosition);
-// typedef setConsoleCursorPositionNative = Int8 Function(
-//     Int32 hConsoleOutput, Int16 dwCursorPositionX, Int16 dwCursorPositionY);
-// typedef setConsoleCursorPositionDart = int Function(
-//     int hConsoleOutput, int dwCursorPositionX, int dwCursorPositionY);
+    int hConsoleOutput, int dwCursorPosition);
 
 main() {
   final DynamicLibrary kernel = DynamicLibrary.open('Kernel32.dll');
@@ -137,16 +134,27 @@ main() {
       setConsoleCursorPositionNative,
       setConsoleCursorPositionDart>("SetConsoleCursorPosition");
 
+  // stdout.write('\x1b[2J\x1b[H'); // clear screen and reset cursor to origin
+
   final outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-  print(outputHandle);
+  print("Output handle (DWORD): $outputHandle");
 
   Pointer<CONSOLE_SCREEN_BUFFER_INFO> pBufferInfo =
       Pointer<CONSOLE_SCREEN_BUFFER_INFO>.allocate();
   CONSOLE_SCREEN_BUFFER_INFO bufferInfo = pBufferInfo.load();
   GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
-  print(bufferInfo.srWindowTop);
-  print(bufferInfo.dwCursorPositionY);
-  // SetConsoleCursorPosition(outputHandle, 5, 20);
-  print(bufferInfo.srWindowTop);
-  print(bufferInfo.dwCursorPositionY);
+  print("Window dimensions LTRB: (${bufferInfo.srWindowLeft}, "
+      "${bufferInfo.srWindowTop}, ${bufferInfo.srWindowRight}, "
+      "${bufferInfo.srWindowBottom})");
+  print("Cursor position X/Y: (${bufferInfo.dwCursorPositionX}, "
+      "${bufferInfo.dwCursorPositionY})");
+  print("Window size X/Y: (${bufferInfo.dwSizeX}, ${bufferInfo.dwSizeY})");
+  print("Maximum window size X/Y: (${bufferInfo.dwMaximumWindowSizeX}, "
+      "${bufferInfo.dwMaximumWindowSizeY})");
+  int cursorPosition = (15 << 16) + 3;
+
+  SetConsoleCursorPosition(outputHandle, cursorPosition);
+  GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
+  print("Cursor position X/Y: (${bufferInfo.dwCursorPositionX}, "
+      "${bufferInfo.dwCursorPositionY})");
 }

--- a/lib/src/console.dart
+++ b/lib/src/console.dart
@@ -82,8 +82,14 @@ class Console {
   bool get rawMode => _isRawMode;
 
   /// Clears the entire screen
-  void clearScreen() =>
+  void clearScreen() {
+    if (Platform.isWindows) {
+      final winTermlib = _termlib as TermLibWindows;
+      winTermlib.clearScreen();
+    } else {
       stdout.write(ansiEraseInDisplayAll + ansiResetCursorPosition);
+    }
+  }
 
   /// Erases all the characters in the current line.
   void eraseLine() => stdout.write(ansiEraseInLineAll);

--- a/lib/src/console.dart
+++ b/lib/src/console.dart
@@ -10,6 +10,7 @@ import 'ansi.dart';
 import 'enums.dart';
 import 'key.dart';
 import 'ffi/termlib.dart';
+import 'ffi/win/termlib-win.dart';
 
 /// A screen position, measured in rows and columns from the top-left origin
 /// of the screen. Coordinates are zero-based, and converted as necessary
@@ -238,7 +239,12 @@ class Console {
   /// Coordinates are measured from the top left of the screen, and are
   /// zero-based.
   set cursorPosition(Coordinate cursor) {
-    stdout.write(ansiCursorPosition(cursor.row + 1, cursor.col + 1));
+    if (Platform.isWindows) {
+      final winTermlib = _termlib as TermLibWindows;
+      winTermlib.setCursorPosition(cursor.col, cursor.row);
+    } else {
+      stdout.write(ansiCursorPosition(cursor.row + 1, cursor.col + 1));
+    }
   }
 
   /// Sets the console foreground color to a named ANSI color.

--- a/lib/src/ffi/win/kernel32.dart
+++ b/lib/src/ffi/win/kernel32.dart
@@ -7,6 +7,8 @@
 
 import 'dart:ffi';
 
+// *** CONSTANTS ***
+
 const STD_INPUT_HANDLE = -10;
 const STD_OUTPUT_HANDLE = -11;
 const STD_ERROR_HANDLE = -12;
@@ -29,11 +31,7 @@ const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
 const DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
 const ENABLE_LVB_GRID_WORLDWIDE = 0x0010;
 
-// HANDLE WINAPI GetStdHandle(
-//   _In_ DWORD nStdHandle
-// );
-typedef getStdHandleNative = Int32 Function(Int32 nStdHandle);
-typedef getStdHandleDart = int Function(int nStdHandle);
+// *** FUNCTIONS ***
 
 // BOOL WINAPI GetConsoleScreenBufferInfo(
 //   _In_  HANDLE                      hConsoleOutput,
@@ -44,13 +42,11 @@ typedef getConsoleScreenBufferInfoNative = Int8 Function(Int32 hConsoleOutput,
 typedef getConsoleScreenBufferInfoDart = int Function(int hConsoleOutput,
     Pointer<CONSOLE_SCREEN_BUFFER_INFO> lpConsoleScreenBufferInfo);
 
-// BOOL WINAPI SetConsoleMode(
-//   _In_ HANDLE hConsoleHandle,
-//   _In_ DWORD  dwMode
+// HANDLE WINAPI GetStdHandle(
+//   _In_ DWORD nStdHandle
 // );
-typedef setConsoleModeNative = Int8 Function(
-    Int32 hConsoleHandle, Int32 dwMode);
-typedef setConsoleModeDart = int Function(int hConsoleHandle, int dwMode);
+typedef getStdHandleNative = Int32 Function(Int32 nStdHandle);
+typedef getStdHandleDart = int Function(int nStdHandle);
 
 // BOOL WINAPI SetConsoleCursorInfo(
 //   _In_       HANDLE              hConsoleOutput,
@@ -61,9 +57,28 @@ typedef setConsoleCursorInfoNative = Int8 Function(
 typedef setConsoleCursorInfoDart = int Function(
     int hConsoleOutput, Pointer<CONSOLE_CURSOR_INFO> lpConsoleCursorInfo);
 
-// Requires unpacking COORD and SMALL_RECT because of
-// missing support for nested structs
-// (https://github.com/dart-lang/sdk/issues/37271)
+// BOOL WINAPI SetConsoleCursorPosition(
+//   _In_ HANDLE hConsoleOutput,
+//   _In_ COORD  dwCursorPosition
+// );
+typedef setConsoleCursorPositionNative = Int8 Function(
+    Int32 hConsoleOutput, Int16 dwCursorPositionX, Int16 dwCursorPositionY);
+typedef setConsoleCursorPositionDart = int Function(
+    int hConsoleOutput, int dwCursorPositionX, int dwCursorPositionY);
+
+// BOOL WINAPI SetConsoleMode(
+//   _In_ HANDLE hConsoleHandle,
+//   _In_ DWORD  dwMode
+// );
+typedef setConsoleModeNative = Int8 Function(
+    Int32 hConsoleHandle, Int32 dwMode);
+typedef setConsoleModeDart = int Function(int hConsoleHandle, int dwMode);
+
+// *** STRUCTS ***
+
+// Dart FFI does not yet have support for nested structs, so there's extra
+// work necessary to unpack parameters like COORD and SMALL_RECT. The Dart
+// issue for this work is https://github.com/dart-lang/sdk/issues/37271.
 
 // typedef struct _CONSOLE_CURSOR_INFO {
 //   DWORD dwSize;
@@ -148,6 +163,11 @@ class COORD extends Struct<COORD> {
 
   @Int16()
   int Y;
+
+  factory COORD.allocate(int X, int Y) =>
+      Pointer<COORD>.allocate().load<COORD>()
+        ..X = X
+        ..Y = Y;
 }
 
 // typedef struct _SMALL_RECT {

--- a/lib/src/ffi/win/kernel32.dart
+++ b/lib/src/ffi/win/kernel32.dart
@@ -33,6 +33,46 @@ const ENABLE_LVB_GRID_WORLDWIDE = 0x0010;
 
 // *** FUNCTIONS ***
 
+// BOOL WINAPI FillConsoleOutputCharacter(
+//   _In_  HANDLE  hConsoleOutput,
+//   _In_  TCHAR   cCharacter,
+//   _In_  DWORD   nLength,
+//   _In_  COORD   dwWriteCoord,
+//   _Out_ LPDWORD lpNumberOfCharsWritten
+// );
+typedef fillConsoleOutputCharacterNative = Int8 Function(
+    Int32 hConsoleOutput,
+    Int8 cCharacter,
+    Int32 nLength,
+    Int32 dwWriteCoord,
+    Pointer<Int32> lpNumberOfCharsWritten);
+typedef fillConsoleOutputCharacterDart = int Function(
+    int hConsoleOutput,
+    int cCharacter,
+    int nLength,
+    int dwWriteCoord,
+    Pointer<Int32> lpNumberOfCharsWritten);
+
+// BOOL WINAPI FillConsoleOutputAttribute(
+//   _In_  HANDLE  hConsoleOutput,
+//   _In_  WORD    wAttribute,
+//   _In_  DWORD   nLength,
+//   _In_  COORD   dwWriteCoord,
+//   _Out_ LPDWORD lpNumberOfAttrsWritten
+// );
+typedef fillConsoleOutputAttributeNative = Int8 Function(
+    Int32 hConsoleOutput,
+    Int16 wAttribute,
+    Int32 nLength,
+    Int32 dwWriteCoord,
+    Pointer<Int32> lpNumberOfAttrsWritten);
+typedef fillConsoleOutputAttributeDart = int Function(
+    int hConsoleOutput,
+    int cCharacter,
+    int nLength,
+    int dwWriteCoord,
+    Pointer<Int32> lpNumberOfAttrsWritten);
+
 // BOOL WINAPI GetConsoleScreenBufferInfo(
 //   _In_  HANDLE                      hConsoleOutput,
 //   _Out_ PCONSOLE_SCREEN_BUFFER_INFO lpConsoleScreenBufferInfo

--- a/lib/src/ffi/win/kernel32.dart
+++ b/lib/src/ffi/win/kernel32.dart
@@ -62,9 +62,9 @@ typedef setConsoleCursorInfoDart = int Function(
 //   _In_ COORD  dwCursorPosition
 // );
 typedef setConsoleCursorPositionNative = Int8 Function(
-    Int32 hConsoleOutput, Int16 dwCursorPositionX, Int16 dwCursorPositionY);
+    Int32 hConsoleOutput, Int32 dwCursorPosition);
 typedef setConsoleCursorPositionDart = int Function(
-    int hConsoleOutput, int dwCursorPositionX, int dwCursorPositionY);
+    int hConsoleOutput, int dwCursorPosition);
 
 // BOOL WINAPI SetConsoleMode(
 //   _In_ HANDLE hConsoleHandle,

--- a/lib/src/ffi/win/termlib-win.dart
+++ b/lib/src/ffi/win/termlib-win.dart
@@ -84,13 +84,7 @@ class TermLibWindows implements TermLib {
   }
 
   void setCursorPosition(int x, int y) {
-    Pointer<CONSOLE_SCREEN_BUFFER_INFO> pBufferInfo =
-        Pointer<CONSOLE_SCREEN_BUFFER_INFO>.allocate();
-    CONSOLE_SCREEN_BUFFER_INFO bufferInfo = pBufferInfo.load();
-    GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
-    SetConsoleCursorPosition(
-        outputHandle, bufferInfo.srWindowLeft + x, bufferInfo.srWindowTop + y);
-    pBufferInfo.free();
+    SetConsoleCursorPosition(outputHandle, (y << 16) + x);
   }
 
   TermLibWindows() {

--- a/lib/src/ffi/win/termlib-win.dart
+++ b/lib/src/ffi/win/termlib-win.dart
@@ -20,6 +20,7 @@ class TermLibWindows implements TermLib {
   getConsoleScreenBufferInfoDart GetConsoleScreenBufferInfo;
   setConsoleModeDart SetConsoleMode;
   setConsoleCursorInfoDart SetConsoleCursorInfo;
+  setConsoleCursorPositionDart SetConsoleCursorPosition;
 
   int inputHandle, outputHandle;
 
@@ -82,6 +83,16 @@ class TermLibWindows implements TermLib {
     lpConsoleCursorInfo.free();
   }
 
+  void setCursorPosition(int x, int y) {
+    Pointer<CONSOLE_SCREEN_BUFFER_INFO> pBufferInfo =
+        Pointer<CONSOLE_SCREEN_BUFFER_INFO>.allocate();
+    CONSOLE_SCREEN_BUFFER_INFO bufferInfo = pBufferInfo.load();
+    GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
+    SetConsoleCursorPosition(
+        outputHandle, bufferInfo.srWindowLeft + x, bufferInfo.srWindowTop + y);
+    pBufferInfo.free();
+  }
+
   TermLibWindows() {
     kernel = DynamicLibrary.open('Kernel32.dll');
 
@@ -95,7 +106,9 @@ class TermLibWindows implements TermLib {
             "SetConsoleMode");
     SetConsoleCursorInfo = kernel.lookupFunction<setConsoleCursorInfoNative,
         setConsoleCursorInfoDart>("SetConsoleCursorInfo");
-
+    SetConsoleCursorPosition = kernel.lookupFunction<
+        setConsoleCursorPositionNative,
+        setConsoleCursorPositionDart>("SetConsoleCursorPosition");
     outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
     inputHandle = GetStdHandle(STD_INPUT_HANDLE);
   }

--- a/lib/src/ffi/win/termlib-win.dart
+++ b/lib/src/ffi/win/termlib-win.dart
@@ -21,6 +21,8 @@ class TermLibWindows implements TermLib {
   setConsoleModeDart SetConsoleMode;
   setConsoleCursorInfoDart SetConsoleCursorInfo;
   setConsoleCursorPositionDart SetConsoleCursorPosition;
+  fillConsoleOutputCharacterDart FillConsoleOutputCharacter;
+  fillConsoleOutputAttributeDart FillConsoleOutputAttribute;
 
   int inputHandle, outputHandle;
 
@@ -83,6 +85,27 @@ class TermLibWindows implements TermLib {
     lpConsoleCursorInfo.free();
   }
 
+  void clearScreen() {
+    Pointer<CONSOLE_SCREEN_BUFFER_INFO> pBufferInfo =
+        Pointer<CONSOLE_SCREEN_BUFFER_INFO>.allocate();
+    CONSOLE_SCREEN_BUFFER_INFO bufferInfo = pBufferInfo.load();
+    GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
+
+    final consoleSize = bufferInfo.dwSizeX * bufferInfo.dwSizeY;
+
+    final pCharsWritten = Pointer<Int32>.allocate();
+    FillConsoleOutputCharacter(
+        outputHandle, ' '.codeUnitAt(0), consoleSize, 0, pCharsWritten);
+
+    GetConsoleScreenBufferInfo(outputHandle, pBufferInfo);
+
+    FillConsoleOutputAttribute(
+        outputHandle, bufferInfo.wAttributes, consoleSize, 0, pCharsWritten);
+
+    SetConsoleCursorPosition(outputHandle, 0);
+    pCharsWritten.free();
+  }
+
   void setCursorPosition(int x, int y) {
     SetConsoleCursorPosition(outputHandle, (y << 16) + x);
   }
@@ -103,6 +126,12 @@ class TermLibWindows implements TermLib {
     SetConsoleCursorPosition = kernel.lookupFunction<
         setConsoleCursorPositionNative,
         setConsoleCursorPositionDart>("SetConsoleCursorPosition");
+    FillConsoleOutputCharacter = kernel.lookupFunction<
+        fillConsoleOutputCharacterNative,
+        fillConsoleOutputCharacterDart>("FillConsoleOutputCharacterA");
+    FillConsoleOutputAttribute = kernel.lookupFunction<
+        fillConsoleOutputAttributeNative,
+        fillConsoleOutputAttributeDart>("FillConsoleOutputAttribute");
     outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
     inputHandle = GetStdHandle(STD_INPUT_HANDLE);
   }


### PR DESCRIPTION
On Win32, while the ANSI clear screen sequence works, it only clears the current visible buffer, rather than the full screen buffer. This pull request uses the native Win32 APIs to clear the screen in the [documented approach recommended by Microsoft](https://docs.microsoft.com/en-us/windows/console/clearing-the-screen) as well as using native APIs to set the cursor position, which seems to be faster in certain scenarios than ANSI escape sequences as well as more compatible with older Windows versions. 