### PR TITLE
Issue-18: Updated the readme.md so that the example works again

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ main() {
   console.clearScreen();
   console.resetCursorPosition();
 
-  console.writeAligned(
-      'Console size is ${console.windowWidth} cols and ${console.windowHeight} rows.',
-      TextAlignment.Center);
+  console.writeLine(
+    'Console size is ${console.windowWidth} cols and ${console.windowHeight} rows.',
+    TextAlignment.center,
+  );
+
   console.writeLine();
 
   return 0;

--- a/example/readme.dart
+++ b/example/readme.dart
@@ -1,0 +1,17 @@
+import 'package:dart_console/dart_console.dart';
+
+int main() {
+  final console = Console();
+
+  console.clearScreen();
+  console.resetCursorPosition();
+
+  console.writeLine(
+    'Console size is ${console.windowWidth} cols and ${console.windowHeight} rows.',
+    TextAlignment.center,
+  );
+
+  console.writeLine();
+
+  return 0;
+}

--- a/test/console_test.dart
+++ b/test/console_test.dart
@@ -1,6 +1,7 @@
 import 'package:dart_console/dart_console.dart';
 
 import 'package:test/test.dart';
+import '../example/readme.dart' as readmeExample;
 
 void main() {
   Console console;
@@ -18,5 +19,9 @@ void main() {
 
     expect(coordinate.row, equals(returnedCoordinate.row));
     expect(coordinate.col, equals(returnedCoordinate.col));
+  });
+
+  test('should run readme example', () {
+    expect(readmeExample.main(), 0);
   });
 }

--- a/test/console_test.dart
+++ b/test/console_test.dart
@@ -1,7 +1,7 @@
 import 'package:dart_console/dart_console.dart';
 
 import 'package:test/test.dart';
-import '../example/readme.dart' as readmeExample;
+import '../example/readme.dart' as readme_example;
 
 void main() {
   Console console;
@@ -22,6 +22,6 @@ void main() {
   });
 
   test('should run readme example', () {
-    expect(readmeExample.main(), 0);
+    expect(readme_example.main(), 0);
   });
 }


### PR DESCRIPTION
I assume that the `writeAligned` is deprecated, so I replaced it with the working method name "writeLine".

Additionally, I added into the examples folder a basic readme.dart and tested if it is working. With that we are sure that the readme example will run with each change.

I know to create a file for this is not optimal maybe we can also remove it and bring the "readme.dart" as a function into the test if you like.