### PR TITLE
Fix pub version matching error on Flutter projects that depends on this package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Sets the dependency constraint more loosely to fix pub version match on flutter projects that depends on this package
+
 ## 1.1.2
 
 - Remove ioctl and rely on ANSI escape sequences instead. Increases

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ platforms:
 dependencies:
   ffi: '>=1.0.0 <3.0.0'
   win32: ^3.0.0
-  intl: ^0.17.0
+  intl: '>=0.0.1 <1.0.0'
   characters: ^1.2.1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_console
-version: 1.1.2
+version: 1.1.3
 homepage: https://github.com/timsneath/dart_console
 description: 
   A helper library for command-line applications that need more control over input/output than the standard library provides.


### PR DESCRIPTION
Hello, I have a flutter project where I use this package as a dev_dependency to a command line tool that I've created to automate some commands that I must run to use the project. Since the launch of Flutter 3.10, today, I'm having an error on pub get saying that intl version are not matching. The new Flutter 3.10 uses intl 0.18.0 and this package was still in 0.17.0 so, to fix this, I am setting the version of intl dependency to be more compatible.
![image](https://github.com/timsneath/dart_console/assets/17789155/21a72b9a-a071-4a2d-8a15-137e65d21ce4)
![image](https://github.com/timsneath/dart_console/assets/17789155/62e85ee3-f3dd-403a-ad7c-7a285b9580c5)
